### PR TITLE
Show bare StormCrawler™ name next to download link for trademark registration

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -19,6 +19,11 @@ title: Download
 
     <h2>Downloads</h2>
 
+    <p>StormCrawler™ software is an open source SDK for building low-latency, scalable web crawlers based on Apache
+        Storm®. You can <a
+            href="https://www.apache.org/dyn/closer.lua/stormcrawler/stormcrawler-3.6.0/apache-stormcrawler-3.6.0-source-release.tar.gz">download
+        StormCrawler™ software here</a> (latest release: 3.6.0), or pick individual artifacts below.</p>
+
     <h3>Apache StormCrawler 3.6.0</h3>
     <br/>
     <ul>


### PR DESCRIPTION
As discussed on the dev mailing list regarding the StormCrawler trademark registration with the USPTO, the examiners need to see the bare `StormCrawler` name (without the `Apache` prefix) together with the ™ symbol, in direct connection with a link where an end user can download the software.

This PR adds a short paragraph to the download page that describes the software product and contains a `download StormCrawler™ software here` hyperlink pointing to the 3.6.0 source release, so counsel can take a screenshot of it for the application. The existing download listings are unchanged.